### PR TITLE
Unify and reduce dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,7 +4513,6 @@ dependencies = [
  "human-panic",
  "image",
  "itertools 0.14.0",
- "lazy_static",
  "notify",
  "open",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,15 @@
 members = ["crates/blerp", "crates/volt"]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88.0"
+
+[workspace.dependencies]
+cpal = "0.15.3"
+itertools = "0.14.0"
+
 # Compile time and runtime optimizations
 [profile.dev]
 opt-level = 1

--- a/crates/blerp/Cargo.toml
+++ b/crates/blerp/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "blerp"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
-cpal = "0.15.3"
-itertools = "0.14.0"
+cpal = { workspace = true }
+itertools = { workspace = true }
 nom = "7.1.3"
 nom_locate = "4.2.0"
 num = "0.4.3"

--- a/crates/volt/Cargo.toml
+++ b/crates/volt/Cargo.toml
@@ -25,5 +25,4 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 notify = { version = "8.0.0", features = ["crossbeam-channel"] }
 crossbeam-channel = "0.5.14"
 paste = "1.0.15"
-lazy_static = "1.5.0"
 unicode-truncate = "2.0.0"

--- a/crates/volt/Cargo.toml
+++ b/crates/volt/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "volt"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
-cpal = "0.15.3"
+cpal = { workspace = true }
+itertools = { workspace = true }
 eframe = { version = "0.30.0", features = ["wgpu"] }
 egui = { version = "0.30.0", features = ["color-hex"] }
 egui_extras = { version = "0.30.0", features = ["all_loaders"] }
 egui_plot = "0.30.0"
 image = { version = "0.25.5", features = ["jpeg", "png"] }
-itertools = "0.14.0"
 open = "5.3.2"
 rodio = { version = "0.20.1", features = ["minimp3"] }
 rustfft = "6.2.0"

--- a/crates/volt/src/timings.rs
+++ b/crates/volt/src/timings.rs
@@ -1,11 +1,7 @@
-use std::sync::{Mutex, Arc};
-use lazy_static::lazy_static;
+use std::sync::{Arc, LazyLock, Mutex};
 
 pub fn now_ns() -> f64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as f64
+    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos() as f64
 }
 
 pub fn ns_to_ms(ns: f64) -> f64 {
@@ -20,13 +16,13 @@ macro_rules! generate_timings {
             )*
         }
 
-        lazy_static! {
-            static ref SHARED_TIMINGS: Arc<Mutex<SharedTimings>> = Arc::new(Mutex::new(SharedTimings {
+        static SHARED_TIMINGS: LazyLock<Arc<Mutex<SharedTimings>>> =
+            LazyLock::new(|| Arc::new(Mutex::new(SharedTimings {
                 $(
-                    $name: 0.0,
+                $name: 0.0,
                 )*
-            }));
-        }
+            }
+        )));
 
         $(
             paste::item! {
@@ -57,6 +53,5 @@ macro_rules! generate_timings {
     };
 }
 
-generate_timings!(
-    render
-);
+generate_timings!(render);
+


### PR DESCRIPTION
These are some trivial changes but I think they will improve the DX of all contributors.

### Unify dependencies and metadata

Setting workspace dependencies in the main `Cargo.toml` will help in terms of building, as `cargo` will cache and optimize the dependency tree.

Besides, having common dependencies and metadata in a single source of truth will avoid the need of duplicate those fields across all crates with the risk of some of them to be forgotten when updating.

I also updated the rust edition to `2024` which include some features that might be useful (if-let chains, etc.) and set the rust-version to the current `1.88.0`, to ensure all contributors are on the same page.

### Remove lazy_static dependency

Since the Rust version has been set to `1.88.0`, I thinks is worth to remove `lazy_static` dependency and use std's [LazyLock](https://doc.rust-lang.org/beta/std/sync/struct.LazyLock.html) instead, which was stabilized in 1.80.0 and is the natural replacement of lazy_static.