### PR TITLE
Fix crash on macOS 26, update dependencies, do some cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,15 +20,15 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "accesskit"
-version = "0.17.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
+checksum = "e25ae84c0260bdf5df07796d7cc4882460de26a2b406ec0e6c42461a723b271b"
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5dd55e6e94949498698daf4d48fb5659e824d7abec0d394089656ceaf99d4f"
+checksum = "29bd41de2e54451a8ca0dd95ebf45b54d349d29ebceb7f20be264eee14e3d477"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -40,34 +40,33 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
+checksum = "8bfae7c152994a31dc7d99b8eeac7784a919f71d1b306f4b83217e110fd3824c"
 dependencies = [
  "accesskit",
- "hashbrown 0.15.1",
- "immutable-chunkmap",
+ "hashbrown",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.18.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
+checksum = "692dd318ff8a7a0ffda67271c4bd10cf32249656f4e49390db0b26ca92b095f2"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown 0.15.1",
- "objc2",
+ "hashbrown",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
 name = "accesskit_unix"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcee751cc20d88678c33edaf9c07e8b693cd02819fe89053776f5313492273f5"
+checksum = "c5f7474c36606d0fe4f438291d667bae7042ea2760f506650ad2366926358fc8"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -83,24 +82,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.24.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
+checksum = "70a042b62c9c05bf7b616f015515c17d2813f3ba89978d6f4fc369735d60700a"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown 0.15.1",
- "paste",
+ "hashbrown",
  "static_assertions",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.23.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
+checksum = "5c1f0d3d13113d8857542a4f8d1a1c24d1dc1527b77aee8426127f4901588708"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -154,19 +152,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611cc2ae7d2e242c457e4be7f97036b8ad9ca152b499f53faf99b1ed8fc2553f"
-
-[[package]]
 name = "alsa"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "libc",
 ]
@@ -188,16 +180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "cc",
  "cesu8",
  "jni",
  "jni-sys",
  "libc",
  "log",
- "ndk 0.9.0",
+ "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -207,15 +199,6 @@ name = "android-properties"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "anstream"
@@ -285,11 +268,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df099ccb16cd014ff054ac1bf392c67feeef57164b05c42f037cd40f5d4357f4"
 dependencies = [
  "clipboard-win",
+ "core-graphics",
+ "image",
  "log",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "parking_lot",
+ "windows-sys 0.48.0",
  "x11rb",
 ]
 
@@ -321,15 +307,6 @@ name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
-
-[[package]]
-name = "ash"
-version = "0.38.0+1.3.281"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
-dependencies = [
- "libloading",
-]
 
 [[package]]
 name = "async-broadcast"
@@ -369,17 +346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
 name = "async-io"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,7 +358,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.40",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -424,7 +390,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.38.40",
  "tracing",
 ]
 
@@ -451,7 +417,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.40",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -482,9 +448,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be534b16650e35237bb1ed189ba2aab86ce65e88cc84c66f4935ba38575cecbf"
+checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
 dependencies = [
  "atspi-common",
  "atspi-connection",
@@ -493,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "atspi-common"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1909ed2dc01d0a17505d89311d192518507e8a056a48148e3598fef5e7bb6ba7"
+checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
 dependencies = [
  "enumflags2",
  "serde",
@@ -509,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "atspi-connection"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430c5960624a4baaa511c9c0fcc2218e3b58f5dbcc47e6190cafee344b873333"
+checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
@@ -521,14 +487,13 @@ dependencies = [
 
 [[package]]
 name = "atspi-proxies"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e6c5de3e524cf967569722446bcd458d5032348554d9a17d7d72b041ab7496"
+checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
 dependencies = [
  "atspi-common",
  "serde",
  "zbus",
- "zvariant",
 ]
 
 [[package]]
@@ -577,33 +542,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.7.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
 
 [[package]]
 name = "bit-set"
@@ -634,9 +575,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -663,21 +607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -713,18 +648,18 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -755,10 +690,10 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "log",
  "polling",
- "rustix",
+ "rustix 0.38.40",
  "slab",
  "thiserror 1.0.69",
 ]
@@ -770,7 +705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop",
- "rustix",
+ "rustix 0.38.40",
  "wayland-backend",
  "wayland-client",
 ]
@@ -793,15 +728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-expr"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,12 +745,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -839,23 +759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
-name = "claxon"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
-
-[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,12 +769,13 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -963,54 +867,42 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce857aa0b77d77287acc1ac3e37a05a8c95a2af3647d23b15f263bdaeb7562b"
-dependencies = [
- "bindgen",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
 dependencies = [
  "alsa",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
  "js-sys",
  "libc",
  "mach2",
- "ndk 0.8.0",
+ "ndk",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.54.0",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1063,16 +955,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,20 +973,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.9.1",
+ "objc2 0.6.1",
+]
 
 [[package]]
 name = "displaydoc"
@@ -1128,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
@@ -1149,9 +1031,9 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "ecolor"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d72e9c39f6e11a2e922d04a34ec5e7ef522ea3f5a1acfca7a19d16ad5fe50f5"
+checksum = "4a631732d995184114016fab22fc7e3faf73d6841c2d7650395fe251fbcd9285"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -1160,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f2d9e7ea2d11ec9e98a8683b6eb99f9d7d0448394ef6e0d6d91bd4eb817220"
+checksum = "0c790ccfbb3dd556588342463454b2b2b13909e5fdce5bc2a1432a8aa69c8b7a"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1171,15 +1053,15 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow 0.16.0",
+ "glow",
  "glutin",
  "glutin-winit",
  "image",
  "js-sys",
  "log",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "parking_lot",
  "percent-encoding",
  "pollster",
@@ -1198,24 +1080,27 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252d52224d35be1535d7fd1d6139ce071fb42c9097773e79f7665604f5596b5e"
+checksum = "8470210c95a42cc985d9ffebfd5067eea55bdb1c3f7611484907db9639675e28"
 dependencies = [
  "accesskit",
  "ahash",
+ "bitflags 2.9.1",
  "emath",
  "epaint",
  "log",
  "nohash-hasher",
  "profiling",
+ "smallvec",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "egui-wgpu"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c1e821d2d8921ef6ce98b258c7e24d9d6aab2ca1f9cdf374eca997e7f67f59"
+checksum = "14de9942d8b9e99e2d830403c208ab1a6e052e925a7456a4f6f66d567d90de1d"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1233,13 +1118,14 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e84c2919cd9f3a38a91e8f84ac6a245c19251fd95226ed9fae61d5ea564fce3"
+checksum = "c490804a035cec9c826082894a3e1ecf4198accd3817deb10f7919108ebafab0"
 dependencies = [
  "accesskit_winit",
  "ahash",
  "arboard",
+ "bytemuck",
  "egui",
  "log",
  "profiling",
@@ -1252,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7a8198c088b1007108cb2d403bc99a5e370999b200db4f14559610d7330126"
+checksum = "0f791a5937f518249016b276b3639ad2aa3824048b6f2161ec2b431ab325880a"
 dependencies = [
  "ahash",
  "egui",
@@ -1269,14 +1155,14 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf6264cc7608e3e69a7d57a6175f438275f1b3889c1a551b418277721c95e6"
+checksum = "d44f3fd4fdc5f960c9e9ef7327c26647edc3141abf96102980647129d49358e6"
 dependencies = [
  "ahash",
  "bytemuck",
  "egui",
- "glow 0.16.0",
+ "glow",
  "log",
  "memoffset",
  "profiling",
@@ -1287,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c226cae80a6ee10c4d3aaf9e33bd9e9b2f1c0116b6036bdc2a1cfc9d2d0dcc10"
+checksum = "524318041a8ea90c81c738e8985f8ad9e3f9bed636b03c2ff37b218113ed5121"
 dependencies = [
  "ahash",
  "egui",
@@ -1318,9 +1204,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "emath"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe73c1207b864ee40aa0b0c038d6092af1030744678c60188a05c28553515d"
+checksum = "45f057b141e7e46340c321400be74b793543b1b213036f0f989c35d35957c32e"
 dependencies = [
  "bytemuck",
 ]
@@ -1347,7 +1233,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
 dependencies = [
  "enum-map-derive",
- "serde",
 ]
 
 [[package]]
@@ -1384,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5666f8d25236293c966fbb3635eac18b04ad1914e3bab55bc7d44b9980cafcac"
+checksum = "94cca02195f0552c17cabdc02f39aa9ab6fbd815dac60ab1cd3d5b0aa6f9551c"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1402,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f6ddac3e6ac6fd4c3d48bb8b1943472f8da0f43a4303bcd8a18aa594401c80"
+checksum = "e8495e11ed527dff39663b8c36b6c2b2799d7e4287fb90556e455d72eca0b4d3"
 
 [[package]]
 name = "equivalent"
@@ -1414,12 +1299,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1427,6 +1312,15 @@ name = "error-code"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
+
+[[package]]
+name = "euclid"
+version = "0.22.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "event-listener"
@@ -1463,6 +1357,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
@@ -1572,9 +1472,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1595,12 +1495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,24 +1507,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1682,24 +1563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "glow"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,8 +1580,8 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec69412a0bf07ea7607e638b415447857a808846c2b685a43c8aa18bc6d5e499"
 dependencies = [
- "bitflags 2.7.0",
- "cfg_aliases 0.2.1",
+ "bitflags 2.9.1",
+ "cfg_aliases",
  "cgl",
  "core-foundation 0.9.4",
  "dispatch",
@@ -1726,9 +1589,9 @@ dependencies = [
  "glutin_glx_sys",
  "glutin_wgl_sys",
  "libloading",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "once_cell",
  "raw-window-handle",
  "wayland-sys",
@@ -1742,7 +1605,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "glutin",
  "raw-window-handle",
  "winit",
@@ -1778,69 +1641,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.7.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.7.0",
-]
-
-[[package]]
-name = "gpu-descriptor"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
-dependencies = [
- "bitflags 2.7.0",
- "gpu-descriptor-types",
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags 2.7.0",
-]
-
-[[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
@@ -1877,12 +1692,6 @@ checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "hound"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "human-panic"
@@ -2074,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imgref"
@@ -2085,22 +1894,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
-name = "immutable-chunkmap"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f97096f508d54f8f8ab8957862eee2ccd628847b6217af1a335e1c44dee578"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2109,7 +1909,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "inotify-sys",
  "libc",
 ]
@@ -2225,22 +2025,12 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "khronos-egl"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
-dependencies = [
- "libc",
- "libloading",
- "pkg-config",
 ]
 
 [[package]]
@@ -2271,11 +2061,13 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.9.5"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
  "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -2291,21 +2083,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
-name = "lewton"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
-dependencies = [
- "byteorder",
- "ogg",
- "tinyvec",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2328,12 +2109,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall 0.5.7",
 ]
@@ -2343,6 +2130,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -2444,11 +2237,11 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -2523,37 +2316,26 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "23.1.0"
+version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364f94bc34f61332abebe8cad6f6cd82a5b65cff22c828d05d0968911462ca4f"
+checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.7.0",
- "cfg_aliases 0.1.1",
+ "bitflags 2.9.1",
+ "cfg_aliases",
  "codespan-reporting",
+ "half",
+ "hashbrown",
  "hexf-parse",
  "indexmap",
  "log",
+ "num-traits",
+ "once_cell",
  "rustc-hash",
- "spirv",
- "termcolor",
- "thiserror 1.0.69",
- "unicode-xid",
-]
-
-[[package]]
-name = "ndk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
-dependencies = [
- "bitflags 2.7.0",
- "jni-sys",
- "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum",
- "thiserror 1.0.69",
+ "strum 0.26.3",
+ "thiserror 2.0.9",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2562,10 +2344,10 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "jni-sys",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -2576,15 +2358,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -2603,13 +2376,13 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
@@ -2653,7 +2426,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -2765,6 +2538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2814,19 +2588,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block2",
  "libc",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cbe18d879e20a4aea544f8befe38bcf52255eb63d3f23eca2842f3319e4c07"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "objc2 0.6.1",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.1",
 ]
 
 [[package]]
@@ -2835,11 +2633,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2849,8 +2647,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca44961e888e19313b808f23497073e3f6b3c22bb485056674c8b49f3b025c82"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.1",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f1cc99bb07ad2ddb6527ddf83db6a15271bb036b3eb94b801cd44fdc666ee1"
+dependencies = [
+ "bitflags 2.9.1",
+ "objc2 0.6.1",
 ]
 
 [[package]]
@@ -2859,10 +2679,21 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.1",
+ "dispatch2",
+ "objc2 0.6.1",
 ]
 
 [[package]]
@@ -2872,8 +2703,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -2884,16 +2715,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-contacts",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
@@ -2901,11 +2732,20 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block2",
  "dispatch",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+dependencies = [
+ "objc2 0.6.1",
 ]
 
 [[package]]
@@ -2915,9 +2755,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2926,10 +2766,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2938,10 +2778,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -2951,8 +2791,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2961,14 +2801,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core",
  "objc2-symbols",
@@ -2983,8 +2823,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2993,11 +2833,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3010,42 +2850,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "oboe"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
-dependencies = [
- "jni",
- "ndk 0.8.0",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "ogg"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "open"
@@ -3139,6 +2947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,7 +3042,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.40",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3238,6 +3052,12 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "ppv-lite86"
@@ -3311,9 +3131,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
@@ -3321,9 +3141,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
@@ -3444,12 +3264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rctree"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f"
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,7 +3278,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3519,9 +3333,9 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "resvg"
-version = "0.37.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadccb3d99a9efb8e5e00c16fbb732cbe400db2ec7fc004697ee7d97d86cf1f4"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
 dependencies = [
  "log",
  "pico-args",
@@ -3557,23 +3371,22 @@ dependencies = [
 
 [[package]]
 name = "rodio"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
+checksum = "e40ecf59e742e03336be6a3d53755e789fd05a059fa22dfa0ed624722319e183"
 dependencies = [
- "claxon",
  "cpal",
- "hound",
- "lewton",
+ "dasp_sample",
  "minimp3_fixed",
+ "num-rational",
  "symphonia",
 ]
 
 [[package]]
 name = "roxmltree"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rustc-demangle"
@@ -3608,11 +3421,24 @@ version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3728,17 +3554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3788,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -3823,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -3833,14 +3648,14 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
  "libc",
  "log",
  "memmap2",
- "rustix",
+ "rustix 0.38.40",
  "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
@@ -3879,15 +3694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
-dependencies = [
- "bitflags 2.7.0",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3920,7 +3726,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -3937,6 +3752,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3944,9 +3771,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svgtypes"
-version = "0.13.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e44e288cd960318917cbd540340968b90becc8bc81f171345d706e7a89d9d70"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
  "kurbo",
  "siphasher",
@@ -3959,9 +3786,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "815c942ae7ee74737bb00f965fa5b5a2ac2ce7b6c01c0cc169bbeaf7abd5f5a9"
 dependencies = [
  "lazy_static",
+ "symphonia-bundle-flac",
  "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e34f34298a7308d4397a6c7fbf5b84c5d491231ce3dd379707ba673ab3bd97"
+dependencies = [
+ "log",
  "symphonia-core",
  "symphonia-metadata",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]
@@ -3974,6 +3820,38 @@ dependencies = [
  "log",
  "symphonia-core",
  "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdbf25b545ad0d3ee3e891ea643ad115aff4ca92f6aec472086b957a58522f70"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f395a67057c2ebc5e84d7bb1be71cce1a7ba99f64e0f0f0e303a03f79116f89b"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a98765fb46a0a6732b007f7e2870c2129b6f78d87db7987e6533c8f164a9f30"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]
@@ -3990,6 +3868,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abfdf178d697e50ce1e5d9b982ba1b94c47218e03ec35022d9f0e071a16dc844"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada3505789516bcf00fc1157c67729eded428b455c27ca370e41f4d785bfa931"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f7be232f962f937f4b7115cbe62c330929345434c834359425e043bfd15f50"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "symphonia-metadata"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3999,6 +3914,16 @@ dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "484472580fa49991afda5f6550ece662237b00c6f562c7d9638d1b086ed010fe"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -4057,7 +3982,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.40",
  "windows-sys 0.59.0",
 ]
 
@@ -4168,21 +4093,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,7 +4123,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -4303,12 +4213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
 name = "uds_windows"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,26 +4249,14 @@ checksum = "8fbf03860ff438702f3910ca5f28f8dac63c1c11e7efb5012b8b175493606330"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width 0.2.1",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -4378,7 +4270,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "flate2",
  "log",
  "once_cell",
@@ -4401,46 +4293,24 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.37.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b0a51b72ab80ca511d126b77feeeb4fb1e972764653e61feac30adc161a756"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
 dependencies = [
- "base64 0.21.7",
- "log",
- "pico-args",
- "usvg-parser",
- "usvg-tree",
- "xmlwriter",
-]
-
-[[package]]
-name = "usvg-parser"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd4e3c291f45d152929a31f0f6c819245e2921bfd01e7bd91201a9af39a2bdc"
-dependencies = [
+ "base64",
  "data-url",
  "flate2",
  "imagesize",
  "kurbo",
  "log",
+ "pico-args",
  "roxmltree",
  "simplecss",
  "siphasher",
- "svgtypes",
- "usvg-tree",
-]
-
-[[package]]
-name = "usvg-tree"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee3d202ebdb97a6215604b8f5b4d6ef9024efd623cf2e373a6416ba976ec7d3"
-dependencies = [
- "rctree",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -4515,11 +4385,11 @@ dependencies = [
  "itertools 0.14.0",
  "notify",
  "open",
- "paste",
+ "pastey",
  "rodio",
  "rustfft",
  "serde",
- "strum",
+ "strum 0.27.2",
  "tap",
  "tracing",
  "tracing-subscriber",
@@ -4544,24 +4414,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -4582,9 +4452,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4592,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4605,19 +4475,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.7"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.0.8",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -4625,12 +4498,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.7"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
- "bitflags 2.7.0",
- "rustix",
+ "bitflags 2.9.1",
+ "rustix 1.0.8",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -4641,7 +4514,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -4652,18 +4525,18 @@ version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b08bc3aafdb0035e7fe0fdf17ba0c09c268732707dca4ae098f60cb28c9e4c"
 dependencies = [
- "rustix",
+ "rustix 0.38.40",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.5"
+version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -4671,11 +4544,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b31cab548ee68c7eb155517f2212049dc151f7cd7910c2b66abfd31c3ee12bd"
+checksum = "a07a14257c077ab3279987c4f8bb987851bf57081b93710381daea94f2c2c032"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4688,7 +4561,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4697,20 +4570,20 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.5"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.36.2",
+ "quick-xml 0.37.5",
  "quote",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.5"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
 dependencies = [
  "dlib",
  "log",
@@ -4720,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4750,8 +4623,8 @@ dependencies = [
  "jni",
  "log",
  "ndk-context",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "url",
  "web-sys",
 ]
@@ -4773,17 +4646,20 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "23.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f70000db37c469ea9d67defdc13024ddf9a5f1b89cb2941b812ad7cde1735a"
+checksum = "ec8fb398f119472be4d80bc3647339f56eb63b2a331f6a3d16e25d8144197dd9"
 dependencies = [
  "arrayvec",
- "cfg_aliases 0.1.1",
+ "bitflags 2.9.1",
+ "cfg_aliases",
  "document-features",
+ "hashbrown",
  "js-sys",
  "log",
  "naga",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -4798,78 +4674,90 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "23.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d63c3c478de8e7e01786479919c8769f62a22eec16788d8c2ac77ce2c132778a"
+checksum = "f7b882196f8368511d613c6aeec80655160db6646aebddf8328879a88d54e500"
 dependencies = [
  "arrayvec",
+ "bit-set",
  "bit-vec",
- "bitflags 2.7.0",
- "cfg_aliases 0.1.1",
+ "bitflags 2.9.1",
+ "cfg_aliases",
  "document-features",
+ "hashbrown",
  "indexmap",
  "log",
  "naga",
  "once_cell",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "rustc-hash",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.9",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
-name = "wgpu-hal"
-version = "23.0.1"
+name = "wgpu-core-deps-apple"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89364b8a0b211adc7b16aeaf1bd5ad4a919c1154b44c9ce27838213ba05fd821"
+checksum = "cfd488b3239b6b7b185c3b045c39ca6bf8af34467a4c5de4e0b1a564135d093d"
 dependencies = [
- "android_system_properties",
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba5fb5f7f9c98baa7c889d444f63ace25574833df56f5b817985f641af58e46"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "25.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f968767fe4d3d33747bbd1473ccd55bf0f6451f55d733b5597e67b5deab4ad17"
+dependencies = [
  "arrayvec",
- "ash",
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block",
- "bytemuck",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "core-graphics-types",
- "glow 0.14.2",
- "glutin_wgl_sys",
- "gpu-alloc",
- "gpu-descriptor",
- "js-sys",
- "khronos-egl",
+ "hashbrown",
  "libc",
  "libloading",
  "log",
  "metal",
  "naga",
- "ndk-sys 0.5.0+25.2.9519653",
  "objc",
- "once_cell",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash",
- "smallvec",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "web-sys",
+ "thiserror 2.0.9",
  "wgpu-types",
- "windows 0.58.0",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "23.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610f6ff27778148c31093f3b03abc4840f9636d58d597ca2f5977433acfe0068"
+checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
+ "bytemuck",
  "js-sys",
+ "log",
+ "thiserror 2.0.9",
  "web-sys",
 ]
 
@@ -4916,12 +4804,24 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4936,22 +4836,33 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.2.0",
+ "windows-link",
+ "windows-result 0.3.4",
  "windows-strings",
- "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4960,13 +4871,29 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -4980,21 +4907,20 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -5004,6 +4930,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5068,6 +5003,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5204,18 +5148,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.30.5"
+version = "0.30.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67"
+checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
 dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "block2",
  "bytemuck",
  "calloop",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics",
@@ -5224,17 +5168,17 @@ dependencies = [
  "js-sys",
  "libc",
  "memmap2",
- "ndk 0.9.0",
- "objc2",
+ "ndk",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
  "pin-project",
  "raw-window-handle",
  "redox_syscall 0.4.1",
- "rustix",
+ "rustix 0.38.40",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
@@ -5259,6 +5203,15 @@ name = "winnow"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -5297,7 +5250,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix",
+ "rustix 0.38.40",
  "x11rb-protocol",
 ]
 
@@ -5314,22 +5267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "xkbcommon-dl"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.1",
  "dlib",
  "log",
  "once_cell",
@@ -5380,13 +5323,12 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "4.4.0"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
 dependencies = [
  "async-broadcast",
  "async-executor",
- "async-fs",
  "async-io",
  "async-lock",
  "async-process",
@@ -5397,20 +5339,16 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-sink",
- "futures-util",
+ "futures-lite",
  "hex",
  "nix",
  "ordered-stream",
- "rand",
  "serde",
  "serde_repr",
- "sha1",
- "static_assertions",
  "tracing",
  "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
+ "windows-sys 0.59.0",
+ "winnow 0.7.12",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -5418,9 +5356,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca2c5dceb099bddaade154055c926bb8ae507a18756ba1d8963fd7b51d8ed1d"
+checksum = "29e96e38ded30eeab90b6ba88cb888d70aef4e7489b6cd212c5e5b5ec38045b6"
 dependencies = [
  "zbus_xml",
  "zvariant",
@@ -5428,9 +5366,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep-macros"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709ab20fc57cb22af85be7b360239563209258430bccf38d8b979c5a2ae3ecce"
+checksum = "dc6821851fa840b708b4cbbaf6241868cabc85a2dc22f426361b0292bfc0b836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5442,35 +5380,38 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.4.0"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
+ "zbus_names",
+ "zvariant",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "3.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
+ "winnow 0.7.12",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "4.0.0"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f374552b954f6abb4bd6ce979e6c9b38fb9d0cd7cc68a7d796e70c9f3a233"
+checksum = "589e9a02bfafb9754bb2340a9e3b38f389772684c63d9637e76b1870377bec29"
 dependencies = [
- "quick-xml 0.30.0",
+ "quick-xml 0.36.2",
  "serde",
  "static_assertions",
  "zbus_names",
@@ -5573,22 +5514,23 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
+version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "static_assertions",
+ "winnow 0.7.12",
  "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "4.2.0"
+version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5599,11 +5541,14 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "2.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde",
+ "static_assertions",
  "syn",
+ "winnow 0.7.12",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-cpal = "0.15.3"
+cpal = "0.16.0"
 itertools = "0.14.0"
 
 # Compile time and runtime optimizations

--- a/crates/blerp/src/processing/generation.rs
+++ b/crates/blerp/src/processing/generation.rs
@@ -7,7 +7,7 @@ pub fn sine_wave(frequency: f64, amplitude: f64) -> impl FnMut(f64) -> f64
 where
     f64: FromSample<f64>,
 {
-    move |time| (amplitude * (TAU * frequency * time).sin())
+    move |time| amplitude * (TAU * frequency * time).sin()
 }
 
 /// Given a `frequency` in hertz and an `amplitude`, return a function over time (in seconds) that generates a square wave.
@@ -26,7 +26,7 @@ pub fn triangle_wave(frequency: f64, amplitude: f64) -> impl FnMut(f64) -> f64
 where
     f64: FromSample<f64>,
 {
-    move |time| ((2. * amplitude) * time.mul_add(frequency, -time.mul_add(frequency, 1. / 2.).floor()).abs())
+    move |time| (2. * amplitude) * time.mul_add(frequency, -time.mul_add(frequency, 1. / 2.).floor()).abs()
 }
 
 /// Given a `frequency` in hertz and an `amplitude`, return a function over time (in seconds) that generates a sawtooth wave.
@@ -34,7 +34,7 @@ pub fn sawtooth_wave(frequency: f64, amplitude: f64) -> impl FnMut(f64) -> f64
 where
     f64: FromSample<f64>,
 {
-    move |time| ((2. * amplitude) * time.mul_add(frequency, -time.mul_add(frequency, 1. / 2.).floor()))
+    move |time| (2. * amplitude) * time.mul_add(frequency, -time.mul_add(frequency, 1. / 2.).floor())
 }
 
 /// Return a function that generates silence.

--- a/crates/volt/Cargo.toml
+++ b/crates/volt/Cargo.toml
@@ -7,16 +7,16 @@ rust-version = { workspace = true }
 [dependencies]
 cpal = { workspace = true }
 itertools = { workspace = true }
-eframe = { version = "0.30.0", features = ["wgpu"] }
-egui = { version = "0.30.0", features = ["color-hex"] }
-egui_extras = { version = "0.30.0", features = ["all_loaders"] }
-egui_plot = "0.30.0"
+eframe = { version = "0.32.0", features = ["wgpu"] }
+egui = { version = "0.32.0", features = ["color-hex"] }
+egui_extras = { version = "0.32.0", features = ["all_loaders"] }
+egui_plot = "0.33.0"
 image = { version = "0.25.5", features = ["jpeg", "png"] }
 open = "5.3.2"
-rodio = { version = "0.20.1", features = ["minimp3"] }
+rodio = { version = "0.21.1", features = ["minimp3"] }
 rustfft = "6.2.0"
 serde = "1.0.217"
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { version = "0.27.2", features = ["derive"] }
 tap = "1.0.1"
 blerp = { path = "../blerp" }
 human-panic = "2.0.2"
@@ -24,5 +24,5 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 notify = { version = "8.0.0", features = ["crossbeam-channel"] }
 crossbeam-channel = "0.5.14"
-paste = "1.0.15"
+pastey = "0.1.1"
 unicode-truncate = "2.0.0"

--- a/crates/volt/src/info.rs
+++ b/crates/volt/src/info.rs
@@ -1,7 +1,7 @@
-use std::{env::args, fs::File, io::stderr, ops::ControlFlow, path::Path, process::Command};
+use std::{env::args, fs::File, io::stderr, ops::ControlFlow, path::Path};
 
 use tracing::{info, subscriber::set_global_default};
-use tracing_subscriber::{fmt::layer, layer::SubscriberExt, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, fmt::layer, layer::SubscriberExt};
 
 fn get_desktop_environment() -> String {
     #[cfg(target_os = "linux")]
@@ -17,11 +17,7 @@ fn get_desktop_environment() -> String {
 fn get_compositor() -> String {
     #[cfg(target_os = "linux")]
     {
-        if std::env::var("WAYLAND_DISPLAY").is_ok() {
-            "Wayland".to_string()
-        } else {
-            "X11".to_string()
-        }
+        if std::env::var("WAYLAND_DISPLAY").is_ok() { "Wayland".to_string() } else { "X11".to_string() }
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -93,12 +89,11 @@ fn get_gpu_info() -> String {
 
     #[cfg(target_os = "macos")]
     {
-        if let Ok(output) = std::process::Command::new("system_profiler").arg("SPDisplaysDataType").output() {
-            if let Ok(stdout) = String::from_utf8(output.stdout) {
-                if let Some(gpu_line) = stdout.lines().find(|line| line.contains("Chipset Model:")) {
-                    return gpu_line.split(':').nth(1).unwrap_or("Unknown GPU").trim().to_string();
-                }
-            }
+        if let Ok(output) = std::process::Command::new("system_profiler").arg("SPDisplaysDataType").output()
+            && let Ok(stdout) = String::from_utf8(output.stdout)
+            && let Some(gpu_line) = stdout.lines().find(|line| line.contains("Chipset Model:"))
+        {
+            return gpu_line.split(':').nth(1).unwrap_or("Unknown GPU").trim().to_string();
         }
     }
 
@@ -159,24 +154,8 @@ pub fn handle_args() -> ControlFlow<(), ()> {
     ControlFlow::Continue(())
 }
 
-// TODO: Refactor this function for better error handling.
 pub fn open_link(link: &str) {
-    if cfg!(target_os = "windows") {
-        Command::new("cmd")
-            .args(["/C", "start", link])
-            .spawn()
-            .expect("Failed to open link");
-    } else if cfg!(target_os = "macos") {
-        Command::new("open")
-            .arg(link)
-            .spawn()
-            .expect("Failed to open link");
-    } else if cfg!(target_os = "linux") {
-        Command::new("xdg-open")
-            .arg(link)
-            .spawn()
-            .expect("Failed to open link");
-    }
+    open::that(link).unwrap_or_else(|_| panic!("`{link}` should be able to be opened"));
 }
 
 pub const BUG_REPORT_URL: &str = "https://github.com/TheRedXD/Volt/issues/new?template=bug_report.md";

--- a/crates/volt/src/main.rs
+++ b/crates/volt/src/main.rs
@@ -1,28 +1,29 @@
 #![warn(clippy::pedantic, clippy::nursery, clippy::allow_attributes_without_reason, clippy::undocumented_unsafe_blocks, clippy::clone_on_ref_ptr)]
 use std::{
     io::{BufReader, Cursor},
-    rc::Rc, time::Duration,
+    rc::Rc,
+    time::{Duration, Instant},
 };
 
-use eframe::{egui, run_native, App, CreationContext, NativeOptions};
-use egui::{hex_color, vec2, CentralPanel, Context, FontData, FontDefinitions, FontFamily, FontId, IconData, Margin, RichText, Rounding, Shadow, SidePanel, TextStyle, TopBottomPanel, Vec2, ViewportBuilder};
+use eframe::{App, CreationContext, NativeOptions, egui, run_native};
+use egui::{CentralPanel, Context, CornerRadius, FontData, FontDefinitions, FontFamily, FontId, IconData, Margin, Shadow, SidePanel, TextStyle, TopBottomPanel, Vec2, ViewportBuilder, hex_color};
 use egui_extras::install_image_loaders;
 use human_panic::setup_panic;
 use image::{ImageFormat, ImageReader};
 use info::handle_args;
 // TODO: Move everything into components (visual)
 mod info;
-mod visual;
 mod timings;
+mod visual;
 
 use tap::{Pipe, Tap};
-use visual::{browser::Browser, central::Central, navbar::navbar, notification::NotificationDrawer, status::status, ThemeColors};
+use visual::{ThemeColors, browser::Browser, central::Central, navbar::navbar, notification::NotificationDrawer, status::status};
 
 fn main() -> eframe::Result {
     setup_panic!();
     if handle_args().is_break() {
         return Ok(());
-    };
+    }
     run_native(
         "Volt",
         NativeOptions {
@@ -55,12 +56,12 @@ struct VoltApp {
     pub theme: Rc<ThemeColors>,
     pub showing_command_palette: bool,
     pub command_palette_text: String,
-    pub command_palette_cursor_pos: u32,
-    pub command_palette_cursor_pos_end: u32,
-    pub command_palette_begin: Duration,
+    pub command_palette_cursor_pos: usize,
+    pub command_palette_cursor_pos_end: usize,
+    pub command_palette_begin: Instant,
     pub timings_toggle: bool,
     pub show_welcome: bool,
-    pub show_about: bool
+    pub show_about: bool,
 }
 
 impl VoltApp {
@@ -102,33 +103,26 @@ impl VoltApp {
             theme,
             showing_command_palette: false,
             command_palette_text: String::new(),
-            command_palette_begin: Duration::default(),
+            command_palette_begin: Instant::now(),
             command_palette_cursor_pos: 0,
             command_palette_cursor_pos_end: 0,
             timings_toggle: false,
             show_welcome: true,
-            show_about: false
+            show_about: false,
         }
     }
-}
-
-fn now() -> f64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs_f64()
 }
 
 impl App for VoltApp {
     #[allow(clippy::too_many_lines, reason = "shut")]
     fn update(&mut self, ctx: &Context, _: &mut eframe::Frame) {
-        let time_render_start = timings::now_ns();
+        let time_render_start = Instant::now();
         // TODO: Move this (the command palette) to its own file. This is here primarily for testing purposes.
 
         // Keyboard shortcut handler
         if ctx.input_mut(|i| i.consume_shortcut(&egui::KeyboardShortcut::new(egui::Modifiers::COMMAND | egui::Modifiers::SHIFT, egui::Key::P))) {
             if !self.showing_command_palette {
-                self.command_palette_begin = Duration::from_secs_f64(now());
+                self.command_palette_begin = Instant::now();
             }
             self.showing_command_palette = !self.showing_command_palette;
         }
@@ -148,7 +142,10 @@ impl App for VoltApp {
                 "bug" => {
                     println!("!!!!!!\nWhen making your bug report, add the information below!\n!!!!!!");
                     info::dump();
-                    self.notification_drawer.make("Dumped system info into console! You'll be redirected to the official Volt bug report page in ~3 seconds.".into(), Some(Duration::from_secs(5)));
+                    self.notification_drawer.make(
+                        "Dumped system info into console! You'll be redirected to the official Volt bug report page in ~3 seconds.".into(),
+                        Some(Duration::from_secs(5)),
+                    );
                     std::thread::spawn(|| {
                         std::thread::sleep(Duration::from_secs(3));
                         info::open_link(info::BUG_REPORT_URL);
@@ -179,15 +176,18 @@ impl App for VoltApp {
                 center_top.y += 40.;
                 let palette_rect = egui::Rect::from_center_size(center_top, palette_size);
 
-                painter.add(Shadow {
-                    spread: 0.0,
-                    blur: 14.0,
-                    offset: vec2(0., 4.),
-                    color: egui::Color32::from_black_alpha(200),
-                }.as_shape(palette_rect, 8.0));
+                painter.add(
+                    Shadow {
+                        spread: 0,
+                        blur: 14,
+                        offset: [0, 4],
+                        color: egui::Color32::from_black_alpha(200),
+                    }
+                    .as_shape(palette_rect, 8.0),
+                );
 
                 painter.rect_filled(palette_rect, 8.0, self.theme.command_palette);
-                painter.rect_stroke(palette_rect, 8.0, (1.0, self.theme.command_palette_border));
+                painter.rect_stroke(palette_rect, 8.0, (1.0, self.theme.command_palette_border), egui::StrokeKind::Middle);
 
                 let palette_text_fontid = FontId::new(12., FontFamily::Monospace);
                 #[allow(clippy::cast_precision_loss, reason = "shut")]
@@ -199,31 +199,31 @@ impl App for VoltApp {
                     })
                 }) {
                     if self.command_palette_cursor_pos == self.command_palette_cursor_pos_end {
-                        self.command_palette_text.insert_str(self.command_palette_cursor_pos as usize, &text);
+                        self.command_palette_text.insert_str(self.command_palette_cursor_pos, &text);
                         self.command_palette_cursor_pos += 1;
                     } else {
-                        let start = self.command_palette_cursor_pos.min(self.command_palette_cursor_pos_end) as usize;
-                        let end = self.command_palette_cursor_pos.max(self.command_palette_cursor_pos_end) as usize;
+                        let start = self.command_palette_cursor_pos.min(self.command_palette_cursor_pos_end);
+                        let end = self.command_palette_cursor_pos.max(self.command_palette_cursor_pos_end);
                         self.command_palette_text.replace_range(start..end, &text);
-                        self.command_palette_cursor_pos = (start as u32) + 1;
+                        self.command_palette_cursor_pos = start + 1;
                     }
                     self.command_palette_cursor_pos_end = self.command_palette_cursor_pos;
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                    self.command_palette_begin = Instant::now();
                 }
 
                 if ctx.input_mut(|i| i.key_pressed(egui::Key::Backspace)) && !self.command_palette_text.is_empty() {
                     if self.command_palette_cursor_pos != self.command_palette_cursor_pos_end {
-                        let start = self.command_palette_cursor_pos.min(self.command_palette_cursor_pos_end) as usize;
-                        let end = self.command_palette_cursor_pos.max(self.command_palette_cursor_pos_end) as usize;
+                        let start = self.command_palette_cursor_pos.min(self.command_palette_cursor_pos_end);
+                        let end = self.command_palette_cursor_pos.max(self.command_palette_cursor_pos_end);
                         self.command_palette_text.replace_range(start..end, "");
-                        self.command_palette_cursor_pos = start as u32;
+                        self.command_palette_cursor_pos = start;
                         self.command_palette_cursor_pos_end = self.command_palette_cursor_pos;
                     } else if self.command_palette_cursor_pos > 0 {
-                        self.command_palette_text.remove(self.command_palette_cursor_pos as usize - 1);
+                        self.command_palette_text.remove(self.command_palette_cursor_pos - 1);
                         self.command_palette_cursor_pos -= 1;
                         self.command_palette_cursor_pos_end = self.command_palette_cursor_pos;
                     }
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                    self.command_palette_begin = Instant::now();
                 }
 
                 if ctx.input_mut(|i| i.key_pressed(egui::Key::ArrowLeft)) {
@@ -237,91 +237,87 @@ impl App for VoltApp {
                     } else {
                         self.command_palette_cursor_pos_end = self.command_palette_cursor_pos;
                     }
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                    self.command_palette_begin = Instant::now();
                 }
 
                 if ctx.input_mut(|i| i.key_pressed(egui::Key::ArrowRight)) {
                     if ctx.input_mut(|i| i.modifiers.shift) {
-                        if (self.command_palette_cursor_pos as usize) < self.command_palette_text.len() {
+                        if self.command_palette_cursor_pos < self.command_palette_text.len() {
                             self.command_palette_cursor_pos += 1;
                         }
-                    } else if (self.command_palette_cursor_pos as usize) < self.command_palette_text.len() {
+                    } else if self.command_palette_cursor_pos < self.command_palette_text.len() {
                         self.command_palette_cursor_pos += 1;
                         self.command_palette_cursor_pos_end = self.command_palette_cursor_pos;
                     } else {
                         self.command_palette_cursor_pos_end = self.command_palette_cursor_pos;
                     }
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                    self.command_palette_begin = Instant::now();
                 }
 
                 if ctx.input_mut(|i| i.modifiers.ctrl && i.key_pressed(egui::Key::ArrowLeft)) {
-                    let text_before = &self.command_palette_text[..(self.command_palette_cursor_pos as usize)];
-                    self.command_palette_cursor_pos = text_before.rfind(|c: char| !c.is_alphanumeric())
-                        .map(|i| i as u32 + 1)
-                        .unwrap_or(0);
+                    let text_before = &self.command_palette_text[..self.command_palette_cursor_pos];
+                    self.command_palette_cursor_pos = text_before.rfind(|c: char| !c.is_alphanumeric()).map_or(0, |i| i + 1);
                     if !ctx.input_mut(|i| i.modifiers.shift) {
                         self.command_palette_cursor_pos_end = self.command_palette_cursor_pos;
                     }
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                    self.command_palette_begin = Instant::now();
                 }
 
                 if ctx.input_mut(|i| i.modifiers.ctrl && i.key_pressed(egui::Key::ArrowRight)) {
-                    let text_after = &self.command_palette_text[(self.command_palette_cursor_pos as usize)..];
+                    let text_after = &self.command_palette_text[self.command_palette_cursor_pos..];
                     if let Some(i) = text_after.find(|c: char| !c.is_alphanumeric()) {
-                        self.command_palette_cursor_pos = (self.command_palette_cursor_pos as usize + i) as u32;
+                        self.command_palette_cursor_pos += i;
                     } else {
-                        self.command_palette_cursor_pos = self.command_palette_text.len() as u32;
+                        self.command_palette_cursor_pos = self.command_palette_text.len();
                     }
                     if !ctx.input_mut(|i| i.modifiers.shift) {
                         self.command_palette_cursor_pos_end = self.command_palette_cursor_pos;
                     }
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                    self.command_palette_begin = Instant::now();
                 }
 
                 if ctx.input_mut(|i| i.modifiers.ctrl && i.key_pressed(egui::Key::Backspace)) {
-                    let text_before = &self.command_palette_text[..(self.command_palette_cursor_pos as usize)];
-                    let prev_word_end = text_before.rfind(|c: char| !c.is_alphanumeric())
-                        .map(|i| i + 1)
-                        .unwrap_or(0);
-                    self.command_palette_text.drain(prev_word_end..self.command_palette_cursor_pos as usize);
-                    self.command_palette_cursor_pos = prev_word_end as u32;
+                    let text_before = &self.command_palette_text[..self.command_palette_cursor_pos];
+                    let prev_word_end = text_before.rfind(|c: char| !c.is_alphanumeric()).map_or(0, |i| i + 1);
+                    self.command_palette_text.drain(prev_word_end..self.command_palette_cursor_pos);
+                    self.command_palette_cursor_pos = prev_word_end;
                     self.command_palette_cursor_pos_end = self.command_palette_cursor_pos;
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                    self.command_palette_begin = Instant::now();
                 }
 
                 if ctx.input_mut(|i| i.key_pressed(egui::Key::Delete)) {
                     if self.command_palette_cursor_pos != self.command_palette_cursor_pos_end {
-                        let start = self.command_palette_cursor_pos.min(self.command_palette_cursor_pos_end) as usize;
-                        let end = self.command_palette_cursor_pos.max(self.command_palette_cursor_pos_end) as usize;
+                        let start = self.command_palette_cursor_pos.min(self.command_palette_cursor_pos_end);
+                        let end = self.command_palette_cursor_pos.max(self.command_palette_cursor_pos_end);
                         self.command_palette_text.replace_range(start..end, "");
-                        self.command_palette_cursor_pos = start as u32;
+                        self.command_palette_cursor_pos = start;
                         self.command_palette_cursor_pos_end = self.command_palette_cursor_pos;
-                    } else if (self.command_palette_cursor_pos as usize) < self.command_palette_text.len() {
-                        self.command_palette_text.remove(self.command_palette_cursor_pos as usize);
+                    } else if self.command_palette_cursor_pos < self.command_palette_text.len() {
+                        self.command_palette_text.remove(self.command_palette_cursor_pos);
                     }
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                    self.command_palette_begin = Instant::now();
                 }
 
-                if ctx.input_mut(|i| i.modifiers.ctrl && i.key_pressed(egui::Key::Delete)) && (self.command_palette_cursor_pos as usize) < self.command_palette_text.len() {
-                    let text_after = &self.command_palette_text[(self.command_palette_cursor_pos as usize)..];
-                    let next_word_start = text_after.find(|c: char| !c.is_alphanumeric())
-                        .map(|i| (self.command_palette_cursor_pos as usize) + i)
-                        .unwrap_or(self.command_palette_text.len());
-                    self.command_palette_text.drain(self.command_palette_cursor_pos as usize..next_word_start);
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                if ctx.input_mut(|i| i.modifiers.ctrl && i.key_pressed(egui::Key::Delete)) && self.command_palette_cursor_pos < self.command_palette_text.len() {
+                    let text_after = &self.command_palette_text[self.command_palette_cursor_pos..];
+                    let next_word_start = text_after
+                        .find(|c: char| !c.is_alphanumeric())
+                        .map_or(self.command_palette_text.len(), |i| self.command_palette_cursor_pos + i);
+                    self.command_palette_text.drain(self.command_palette_cursor_pos..next_word_start);
+                    self.command_palette_begin = Instant::now();
                 }
 
                 if ctx.input_mut(|i| i.modifiers.shift && i.key_pressed(egui::Key::Delete)) {
                     self.command_palette_text.clear();
                     self.command_palette_cursor_pos = 0;
                     self.command_palette_cursor_pos_end = 0;
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                    self.command_palette_begin = Instant::now();
                 }
 
                 if ctx.input_mut(|i| i.modifiers.ctrl && i.key_pressed(egui::Key::A)) {
-                    self.command_palette_cursor_pos = self.command_palette_text.len() as u32;
+                    self.command_palette_cursor_pos = self.command_palette_text.len();
                     self.command_palette_cursor_pos_end = 0;
-                    self.command_palette_begin = Duration::from_secs_f64(now());
+                    self.command_palette_begin = Instant::now();
                 }
 
                 let cptext_x_offset = 10.;
@@ -340,19 +336,21 @@ impl App for VoltApp {
                         self.theme.command_palette_placeholder_text,
                     );
                     // Draw cursor
-                    let cursor_pos = painter.text(
-                        {
-                            let mut lc = palette_rect.left_center();
-                            lc.x += cptext_x_offset;
-                            lc
-                        },
-                        egui::Align2::LEFT_CENTER,
-                        &self.command_palette_text[..self.command_palette_cursor_pos as usize],
-                        palette_text_fontid,
-                        self.theme.command_palette_text,
-                    ).right();
+                    let cursor_pos = painter
+                        .text(
+                            {
+                                let mut lc = palette_rect.left_center();
+                                lc.x += cptext_x_offset;
+                                lc
+                            },
+                            egui::Align2::LEFT_CENTER,
+                            &self.command_palette_text[..self.command_palette_cursor_pos],
+                            palette_text_fontid,
+                            self.theme.command_palette_text,
+                        )
+                        .right();
                     // Only show cursor every 500ms
-                    if (now() - self.command_palette_begin.as_secs_f64()).fract() < 0.5 {
+                    if self.command_palette_begin.elapsed().as_secs_f32().fract() < 0.5 {
                         painter.rect_filled(
                             egui::Rect::from_min_max(
                                 egui::pos2(cursor_pos, palette_rect.center().y - 8.),
@@ -370,32 +368,33 @@ impl App for VoltApp {
                     };
 
                     // Draw text before selection
-                    let selection_start = painter.text(
-                        {
-                            let mut lc = palette_rect.left_center();
-                            lc.x += cptext_x_offset;
-                            lc
-                        },
-                        egui::Align2::LEFT_CENTER,
-                        &self.command_palette_text[..start_pos as usize],
-                        palette_text_fontid.clone(),
-                        self.theme.command_palette_text,
-                    ).right();
+                    let selection_start = painter
+                        .text(
+                            {
+                                let mut lc = palette_rect.left_center();
+                                lc.x += cptext_x_offset;
+                                lc
+                            },
+                            egui::Align2::LEFT_CENTER,
+                            &self.command_palette_text[..start_pos],
+                            palette_text_fontid.clone(),
+                            self.theme.command_palette_text,
+                        )
+                        .right();
 
                     // Draw selection
-                    let selection_end = painter.text(
-                        egui::pos2(selection_start, palette_rect.center().y),
-                        egui::Align2::LEFT_CENTER,
-                        &self.command_palette_text[start_pos as usize..end_pos as usize],
-                        palette_text_fontid.clone(),
-                        hex_color!("8c8cff"),
-                    ).right();
+                    let selection_end = painter
+                        .text(
+                            egui::pos2(selection_start, palette_rect.center().y),
+                            egui::Align2::LEFT_CENTER,
+                            &self.command_palette_text[start_pos..end_pos],
+                            palette_text_fontid.clone(),
+                            hex_color!("8c8cff"),
+                        )
+                        .right();
 
                     painter.rect_filled(
-                        egui::Rect::from_min_max(
-                            egui::pos2(selection_start, palette_rect.center().y - 8.),
-                            egui::pos2(selection_end, palette_rect.center().y + 8.),
-                        ),
+                        egui::Rect::from_min_max(egui::pos2(selection_start, palette_rect.center().y - 8.), egui::pos2(selection_end, palette_rect.center().y + 8.)),
                         0.0,
                         egui::Color32::from_rgba_unmultiplied(0x5c, 0x5c, 0xff, 0x20),
                     );
@@ -404,13 +403,13 @@ impl App for VoltApp {
                     painter.text(
                         egui::pos2(selection_end, palette_rect.center().y),
                         egui::Align2::LEFT_CENTER,
-                        &self.command_palette_text[end_pos as usize..],
+                        &self.command_palette_text[end_pos..],
                         palette_text_fontid,
                         self.theme.command_palette_text,
                     );
 
                     // Only show cursor every 500ms
-                    if (now() - self.command_palette_begin.as_secs_f64()).fract() < 0.5 {
+                    if self.command_palette_begin.elapsed().as_secs_f32().fract() < 0.5 {
                         let cursor_pos = if self.command_palette_cursor_pos <= self.command_palette_cursor_pos_end {
                             selection_start
                         } else {
@@ -432,40 +431,32 @@ impl App for VoltApp {
             }
         }
 
-        egui::Area::new("center_area".into())
-            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
-            .show(ctx, |ui| {
-                if self.show_welcome {
-                    egui::Frame::none()
-                        .fill(self.theme.central_background)
-                        .stroke(egui::Stroke::new(1., self.theme.playlist_bar))
-                        .rounding(Rounding::ZERO.at_least(5.))
-                        .inner_margin(Margin::same(10.))
-                        .show(ui, |ui| {
-                            ui.label("Welcome to Volt!");
-                            ui.label("This is extremely work-in-progress and is not finished at all!");
-                            ui.label("If you can, please check out our GitHub repository:");
-                            ui.hyperlink_to("github.com/TheRedXD/Volt", "https://github.com/TheRedXD/Volt");
-                            ui.style_mut().spacing.item_spacing = Vec2::ZERO;
-                            let mut margin = Margin::ZERO;
-                            margin.top = 5.;
-                            egui::Frame::none()
-                                .inner_margin(margin)
-                                .show(ui, |ui| {
-                                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                                        let close_btn = egui::Button::new("Ok")
-                                            .fill(self.theme.command_palette)
-                                            .stroke(
-                                                egui::Stroke::new(1., self.theme.playlist_bar)
-                                            );
-                                        if ui.add(close_btn).on_hover_cursor(egui::CursorIcon::PointingHand).clicked() {
-                                            self.show_welcome = false
-                                        }
-                                    });
-                                });
+        egui::Area::new("center_area".into()).anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO).show(ctx, |ui| {
+            if self.show_welcome {
+                egui::Frame::new()
+                    .fill(self.theme.central_background)
+                    .stroke(egui::Stroke::new(1., self.theme.playlist_bar))
+                    .corner_radius(CornerRadius::ZERO.at_least(5))
+                    .inner_margin(Margin::same(10))
+                    .show(ui, |ui| {
+                        ui.label("Welcome to Volt!");
+                        ui.label("This is extremely work-in-progress and is not finished at all!");
+                        ui.label("If you can, please check out our GitHub repository:");
+                        ui.hyperlink_to("github.com/TheRedXD/Volt", "https://github.com/TheRedXD/Volt");
+                        ui.style_mut().spacing.item_spacing = Vec2::ZERO;
+                        let mut margin = Margin::ZERO;
+                        margin.top = 5;
+                        egui::Frame::new().inner_margin(margin).show(ui, |ui| {
+                            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                                let close_btn = egui::Button::new("Ok").fill(self.theme.command_palette).stroke(egui::Stroke::new(1., self.theme.playlist_bar));
+                                if ui.add(close_btn).on_hover_cursor(egui::CursorIcon::PointingHand).clicked() {
+                                    self.show_welcome = false;
+                                }
+                            });
                         });
-                }
-            });
+                    });
+            }
+        });
 
         TopBottomPanel::top("navbar").frame(egui::Frame::default()).show_separator_line(false).show(ctx, |ui| {
             ui.add(navbar(&self.theme));
@@ -473,9 +464,13 @@ impl App for VoltApp {
         TopBottomPanel::bottom("status").frame(egui::Frame::default()).show_separator_line(false).show(ctx, |ui| {
             ui.add(status(&self.theme));
         });
-        SidePanel::left("browser").default_width(300.).frame(egui::Frame::default().fill(self.theme.browser)).show_separator_line(false).show(ctx, |ui| {
-            ui.add(&mut self.browser);
-        });
+        SidePanel::left("browser")
+            .default_width(300.)
+            .frame(egui::Frame::default().fill(self.theme.browser))
+            .show_separator_line(false)
+            .show(ctx, |ui| {
+                ui.add(&mut self.browser);
+            });
         CentralPanel::default().frame(egui::Frame::default().fill(self.theme.central_background)).show(ctx, |ui| {
             ui.add(&mut self.central);
         });
@@ -484,9 +479,9 @@ impl App for VoltApp {
             .anchor(egui::Align2::RIGHT_BOTTOM, egui::Vec2::new(ctx.screen_rect().max.x, ctx.screen_rect().max.y))
             .show(ctx, |ui| {
                 egui::Frame {
-                    inner_margin: egui::Margin::same(0.0),
-                    outer_margin: egui::Margin::same(0.0),
-                    rounding: egui::Rounding::same(0.0),
+                    inner_margin: egui::Margin::same(0),
+                    outer_margin: egui::Margin::same(0),
+                    corner_radius: egui::CornerRadius::same(0),
                     shadow: Shadow::NONE,
                     fill: egui::Color32::TRANSPARENT,
                     stroke: egui::Stroke::NONE,
@@ -495,12 +490,10 @@ impl App for VoltApp {
                     ui.add(&mut self.notification_drawer);
                 });
             });
-        let time_render_end = timings::now_ns();
-        let time_render_elapsed = time_render_end - time_render_start;
-        timings::set_render_time(time_render_elapsed);
+        timings::set_render_time(time_render_start.elapsed());
 
         if self.timings_toggle {
-            timings::show_timings(ctx, "Timings", 4);
+            timings::show_timings(ctx, "Timings");
         }
     }
 

--- a/crates/volt/src/timings.rs
+++ b/crates/volt/src/timings.rs
@@ -1,51 +1,44 @@
+use std::time::Duration;
 use std::sync::{Arc, LazyLock, Mutex};
-
-pub fn now_ns() -> f64 {
-    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos() as f64
-}
-
-pub fn ns_to_ms(ns: f64) -> f64 {
-    ns / 1_000_000.0
-}
 
 macro_rules! generate_timings {
     ($($name:ident),*) => {
         struct SharedTimings {
             $(
-                $name: f64,
+                $name: Duration,
             )*
         }
 
         static SHARED_TIMINGS: LazyLock<Arc<Mutex<SharedTimings>>> =
             LazyLock::new(|| Arc::new(Mutex::new(SharedTimings {
                 $(
-                $name: 0.0,
+                $name: Duration::ZERO,
                 )*
             }
         )));
 
         $(
-            paste::item! {
-                #[allow(dead_code)]
-                pub fn [<get_ $name _time>]() -> f64 {
+            pastey::paste! {
+                #[allow(dead_code, reason = "this is a debugging tool")]
+                pub fn [<get_ $name _time>]() -> Duration {
                     SHARED_TIMINGS.lock().unwrap().$name
                 }
 
-                #[allow(dead_code)]
-                pub fn [<set_ $name _time>](time: f64) {
+                #[allow(dead_code, reason = "this is a debugging tool")]
+                pub fn [<set_ $name _time>](time: Duration) {
                     SHARED_TIMINGS.lock().unwrap().$name = time;
                 }
             }
         )*
 
-        #[allow(dead_code)]
-        pub fn show_timings(ctx: &egui::Context, window_name: &str, accuracy: usize) {
+        #[allow(dead_code, reason = "this is a debugging tool")]
+        pub fn show_timings(ctx: &egui::Context, window_name: &str) {
             egui::Window::new(window_name)
                 .collapsible(false)
                 .show(ctx, |ui| {
                     $(
-                        paste::item! {
-                            ui.label(format!("{}: {:.accuracy$}ms", stringify!($name), ns_to_ms([<get_ $name _time>]()), accuracy = accuracy));
+                        pastey::paste! {
+                            ui.label(format!("{}: {:?}", stringify!($name), [<get_ $name _time>]()));
                         }
                     )*
                 });
@@ -54,4 +47,3 @@ macro_rules! generate_timings {
 }
 
 generate_timings!(render);
-

--- a/crates/volt/src/visual/browser.rs
+++ b/crates/volt/src/visual/browser.rs
@@ -1,14 +1,13 @@
 use blerp::utils::zip;
 use itertools::Itertools;
-use notify::{recommended_watcher, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher, recommended_watcher};
 use open::that_detached;
-use rodio::{Decoder, OutputStream, Sink, Source};
-use unicode_truncate::UnicodeTruncateStr;
+use rodio::{Decoder, OutputStreamBuilder, Sink, Source};
 use std::{
     borrow::Cow,
     collections::HashMap,
     f32::consts::FRAC_PI_2,
-    fs::{read_dir, File},
+    fs::{File, read_dir},
     io::BufReader,
     iter::Iterator,
     ops::BitOr,
@@ -24,14 +23,18 @@ use std::{
 use strum::Display;
 use tap::Pipe;
 use tracing::{error, trace};
+use unicode_truncate::UnicodeTruncateStr;
 
 use egui::{
-    emath::{self, TSTransform}, epaint::text::FontPriority, include_image, vec2, Button, Color32, Context, CursorIcon, DragAndDrop, DroppedFile, FontId, Id, Image, Label, LayerId, Margin, Order, Response, RichText, ScrollArea, Sense, Separator, Shape, Stroke, Ui, UiBuilder, Vec2, Widget
+    Button, Color32, Context, CursorIcon, DragAndDrop, DroppedFile, FontId, Id, Image, LayerId, Margin, Order, Response, RichText, ScrollArea, Sense, Separator, Shape, Stroke, Ui, UiBuilder, Vec2,
+    Widget,
+    emath::{self, TSTransform},
+    include_image, vec2,
 };
 
-use crossbeam_channel::{bounded, unbounded, Receiver, Sender, TryRecvError};
+use crossbeam_channel::{Receiver, Sender, TryRecvError, bounded, unbounded};
 
-use crate::visual::{browser, ThemeColors};
+use crate::visual::ThemeColors;
 
 // https://veykril.github.io/tlborm/decl-macros/building-blocks/counting.html#bit-twiddling
 macro_rules! count_tts {
@@ -179,8 +182,8 @@ impl Browser {
                 let (file_data_tx, file_data_rx) = unbounded();
                 // FIXME: Temporary rodio playback, might need to use cpal or make rodio proper
                 spawn(move || {
-                    let (_stream, handle) = OutputStream::try_default().unwrap();
-                    let sink = Sink::try_new(&handle).unwrap();
+                    let stream = OutputStreamBuilder::open_default_stream().unwrap();
+                    let sink = Sink::connect_new(stream.mixer());
                     let mut last_path = None;
                     loop {
                         let Ok(path) = path_rx.recv() else {
@@ -233,7 +236,7 @@ impl Browser {
             let watch_result = cached_entry_kinds.watcher.watch(path.parent().unwrap_or(path), RecursiveMode::NonRecursive);
             if let Err(error) = watch_result {
                 error!("Unexpected error while trying to watch directory: {:?}", error);
-            };
+            }
             trace!("entry kind cache miss for {:?}", path);
             if path.is_dir() {
                 EntryKind::Directory
@@ -305,14 +308,14 @@ impl Browser {
         scroll_area
             .show_rows(ui, Self::ENTRY_HEIGHT, entries.len(), |ui, row_range| {
                 egui::Frame::default()
-                    .inner_margin(Margin::same(8.))
+                    .inner_margin(Margin::same(8))
                     .show(ui, |ui| {
                         ui.vertical(|ui| {
                             ui.visuals_mut().widgets.noninteractive.fg_stroke.color = self.theme.browser_folder_text;
                             ui.visuals_mut().widgets.hovered.fg_stroke.color = self.theme.browser_folder_hover_text;
                             ui.style_mut().spacing.item_spacing.x = 4.;
                             let entries_iter = entries.into_iter();
-                            for entry in entries_iter.skip(row_range.start).take(row_range.len()+8) {
+                            for entry in entries_iter.skip(row_range.start).take(row_range.len() + 8) {
                                 self.add_entry(entry, ui, browser_width);
                             }
                         })
@@ -399,7 +402,7 @@ impl Browser {
                     match &mut entries[len - 1].data {
                         Poll::Ready(EntryData { path, .. }) => *path = entry,
                         Poll::Pending => unreachable!(),
-                    };
+                    }
                 }
             }
             Poll::Pending => match rx.try_recv() {
@@ -438,7 +441,8 @@ impl Browser {
         let char_length = name.to_string().len();
         let mut final_char_length = char_length;
         let mut final_text = name.to_string();
-        let available_width = browser_width - 30. - (INDENT_SIZE * depth as f32);
+        #[allow(clippy::cast_precision_loss, reason = "this is a visual effect")]
+        let available_width = INDENT_SIZE.mul_add(-(depth as f32), browser_width - 30.);
         if full_width > available_width {
             for i in char_length..0 {
                 let string = name.to_string();
@@ -471,7 +475,7 @@ impl Browser {
                         EntryKind::Audio => self.add_audio_entry(&path, ui, &Rc::clone(&self.theme), button),
                         EntryKind::File => Self::add_file(ui, button(&self.theme)),
                         EntryKind::Directory => {
-                            ui.horizontal(|ui| ui.add(self.collapsing_header_icon(f32::from(self.expanded_paths.iter().any(|expanded| *expanded == path)))) | ui.add(button(&self.theme)))
+                            ui.horizontal(|ui| ui.add(self.collapsing_header_icon(f32::from(self.expanded_paths.contains(&path)))) | ui.add(button(&self.theme)))
                                 .inner
                         }
                     }
@@ -582,7 +586,11 @@ impl Widget for &mut Browser {
             ui.visuals_mut().extreme_bg_color = Color32::from_hex("#7676a340").unwrap();
             // ui.style_mut().spacing.scroll.floating = false;
             let scroll_area = ScrollArea::both()
-                .drag_to_scroll(false)
+                .scroll_source(egui::scroll_area::ScrollSource {
+                    scroll_bar: true,
+                    drag: false,
+                    mouse_wheel: true,
+                })
                 .auto_shrink(false)
                 // .hscroll(false)
                 .max_width(ui.available_width() - 6.)

--- a/crates/volt/src/visual/central.rs
+++ b/crates/volt/src/visual/central.rs
@@ -5,8 +5,9 @@ use std::{collections::HashMap, num::NonZeroU64};
 use blerp::processing::effects::clip::ClipEffect;
 use blerp::processing::effects::scale::ScaleEffect;
 use eframe::egui;
+use egui::scroll_area::ScrollSource;
 use egui::{
-    hex_color, pos2, scroll_area::ScrollBarVisibility, vec2, Align, Align2, Color32, CursorIcon, Frame, Id, InputState, Layout, Rect, Response, ScrollArea, Sense, Stroke, Ui, UiBuilder, Vec2, Widget,
+    Align, Align2, Color32, CursorIcon, Frame, Id, InputState, Layout, Rect, Response, ScrollArea, Sense, Stroke, Ui, UiBuilder, Vec2, Widget, hex_color, pos2, scroll_area::ScrollBarVisibility, vec2,
 };
 use graph::{Graph, Node, NodeData, NodeId};
 use itertools::Itertools;
@@ -47,7 +48,7 @@ mod graph {
 
 mod playlist {
     use cpal::Sample;
-    use egui::{vec2, Vec2};
+    use egui::{Vec2, vec2};
     use itertools::Itertools;
     use rodio::{Decoder, Source};
     use std::{fs::File, io::BufReader, path::PathBuf, time::Duration};
@@ -269,8 +270,11 @@ impl Central {
         playlist.zoom = playlist.zoom.max(vec2(50., 50.));
         ScrollArea::both()
             .auto_shrink(false)
-            .drag_to_scroll(false)
-            .enable_scrolling(ui.input(|input| !input.modifiers.alt))
+            .scroll_source(ScrollSource {
+                scroll_bar: true,
+                drag: false,
+                mouse_wheel: ui.input(|input| input.modifiers.alt),
+            })
             .scroll_bar_visibility(ScrollBarVisibility::AlwaysHidden)
             .show(ui, |ui| {
                 let response = ui
@@ -282,18 +286,18 @@ impl Central {
                                     .fill(ThemeColors::default().central_background)
                                     .show(ui, |ui| {
                                         let (response, painter) = ui.allocate_painter(vec2(f32::INFINITY, playlist.zoom.y), Sense::hover());
-                                        if let Some(path) = response.dnd_release_payload::<PathBuf>() {
-                                            if let Some(start) = Time::from_beats(
+                                        if let Some(path) = response.dnd_release_payload::<PathBuf>()
+                                            && let Some(start) = Time::from_beats(
                                                 f64::from((ui.input(|input| input.pointer.latest_pos().unwrap().x) - response.rect.min.x) / playlist.zoom.x)
                                                     * f64::from(playlist.time_signature.beats_per_measure),
-                                            ) {
-                                                playlist.clips.push(Clip {
-                                                    start,
-                                                    track: y,
-                                                    data: ClipData::from_path((*path).clone()),
-                                                });
-                                            }
-                                        };
+                                            )
+                                        {
+                                            playlist.clips.push(Clip {
+                                                start,
+                                                track: y,
+                                                data: ClipData::from_path((*path).clone()),
+                                            });
+                                        }
                                         #[allow(clippy::cast_precision_loss, reason = "rounding errors are negligible because this is a visual effect")]
                                         #[allow(clippy::cast_possible_truncation, reason = "truncation only occurs at unreasonably high numbers")]
                                         for Clip { start, track, data } in &playlist.clips {
@@ -304,7 +308,7 @@ impl Central {
                                             let width =
                                                 playlist.duration_of_clip(data).as_secs_f32() * playlist.tempo.bps() as f32 / playlist.time_signature.beats_per_measure as f32 * playlist.zoom.x;
                                             let rect = Rect::from_min_size(pos2(left, painter.clip_rect().top()), vec2(width, painter.clip_rect().height()));
-                                            painter.rect(rect, 4., Color32::GRAY, Stroke::new(2., Color32::DARK_GRAY));
+                                            painter.rect(rect, 4., Color32::GRAY, Stroke::new(2., Color32::DARK_GRAY), egui::StrokeKind::Middle);
                                             painter.debug_text(
                                                 rect.left_top(),
                                                 Align2::LEFT_TOP,
@@ -346,9 +350,9 @@ impl Central {
                     .iter()
                     .map(|(id, node)| {
                         let response = ui
-                            .allocate_new_ui(UiBuilder::new().max_rect(Rect::from_min_size(rect.center() + node.position + *pan_offset, Vec2::INFINITY)), |ui| {
+                            .scope_builder(UiBuilder::new().max_rect(Rect::from_min_size(rect.center() + node.position + *pan_offset, Vec2::INFINITY)), |ui| {
                                 Frame::default()
-                                    .rounding(4.)
+                                    .corner_radius(4)
                                     .inner_margin(4.)
                                     .stroke(Stroke::new(1., hex_color!("80808080")))
                                     .show(ui, |ui| {

--- a/crates/volt/src/visual/navbar.rs
+++ b/crates/volt/src/visual/navbar.rs
@@ -1,46 +1,72 @@
 use eframe::egui;
-use egui::{include_image, Color32, Image, RichText, TextureOptions, Ui, Vec2, Widget};
+use egui::{Color32, Image, TextureOptions, Ui, Vec2, Widget, include_image};
 
 use super::ThemeColors;
 
 pub fn navbar_menu_buttons(ui: &mut Ui) -> egui::Response {
-    egui::Frame::none().show(ui, |ui| {
-        ui.scope(|ui| {
-            ui.visuals_mut().widgets.inactive.weak_bg_fill = Color32::TRANSPARENT;
-            ui.visuals_mut().widgets.hovered.weak_bg_fill = Color32::TRANSPARENT;
-            ui.visuals_mut().widgets.active.weak_bg_fill = Color32::TRANSPARENT;
-            ui.add_space(5.0);
-            ui.menu_button("File", |ui| {
-                if ui.button("New").clicked() {}
-                if ui.button("Open").clicked() {}
-                if ui.button("Save").clicked() {}
-                if ui.button("Exit").clicked() {
-                    ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
-                }
+    egui::Frame::new()
+        .show(ui, |ui| {
+            ui.scope(|ui| {
+                ui.visuals_mut().widgets.inactive.weak_bg_fill = Color32::TRANSPARENT;
+                ui.visuals_mut().widgets.hovered.weak_bg_fill = Color32::TRANSPARENT;
+                ui.visuals_mut().widgets.active.weak_bg_fill = Color32::TRANSPARENT;
+                ui.add_space(5.0);
+                ui.menu_button("File", |ui| {
+                    if ui.button("New").clicked() {
+                        todo!();
+                    }
+                    if ui.button("Open").clicked() {
+                        todo!();
+                    }
+                    if ui.button("Save").clicked() {
+                        todo!();
+                    }
+                    if ui.button("Exit").clicked() {
+                        ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                    }
+                });
+                ui.add_space(5.0);
+                ui.menu_button("Edit", |ui| {
+                    if ui.button("Undo").clicked() {
+                        todo!();
+                    }
+                    if ui.button("Redo").clicked() {
+                        todo!();
+                    }
+                    if ui.button("Cut").clicked() {
+                        todo!();
+                    }
+                    if ui.button("Copy").clicked() {
+                        todo!();
+                    }
+                    if ui.button("Paste").clicked() {
+                        todo!();
+                    }
+                });
+                ui.add_space(5.0);
+                ui.menu_button("View", |ui| {
+                    if ui.button("Zoom In").clicked() {
+                        todo!();
+                    }
+                    if ui.button("Zoom Out").clicked() {
+                        todo!();
+                    }
+                    if ui.button("Fit to Screen").clicked() {
+                        todo!();
+                    }
+                });
+                ui.add_space(5.0);
+                ui.menu_button("Help", |ui| {
+                    if ui.button("Documentation").clicked() {
+                        todo!();
+                    }
+                    if ui.button("About").clicked() {
+                        todo!();
+                    }
+                });
             });
-            ui.add_space(5.0);
-            ui.menu_button("Edit", |ui| {
-                if ui.button("Undo").clicked() {}
-                if ui.button("Redo").clicked() {}
-                if ui.button("Cut").clicked() {}
-                if ui.button("Copy").clicked() {}
-                if ui.button("Paste").clicked() {}
-            });
-            ui.add_space(5.0);
-            ui.menu_button("View", |ui| {
-                if ui.button("Zoom In").clicked() {}
-                if ui.button("Zoom Out").clicked() {}
-                if ui.button("Fit to Screen").clicked() {}
-            });
-            ui.add_space(5.0);
-            ui.menu_button("Help", |ui| {
-                if ui.button("Documentation").clicked() {}
-                if ui.button("About").clicked() {
-                    
-                }
-            });
-        });
-    }).response
+        })
+        .response
 }
 
 pub fn navbar(themes: &ThemeColors) -> impl Widget + use<'_> {
@@ -57,40 +83,41 @@ pub fn navbar(themes: &ThemeColors) -> impl Widget + use<'_> {
         ui.horizontal(|ui| {
             egui::Frame::default().show(ui, |ui| {
                 ui.horizontal(|ui| {
-                    egui::Frame::none()
-                        .show(ui, |ui| {
-                            ui.style_mut().spacing.item_spacing = Vec2::ZERO;
-                            egui::Frame::none()
-                                .outer_margin(egui::Margin::same(5.))
-                                .inner_margin(egui::Margin::same(5.))
-                                .rounding(egui::Rounding::same(5.))
-                                .fill(themes.navbar_widget)
-                                .show(ui, |ui| {
-                                    egui::Frame::none()
-                                        .inner_margin(egui::Margin::symmetric(5., 0.))
-                                        .show(ui, |ui| {
-                                            ui.add(Image::new(include_image!("../images/icons/navbar-icon.svg")).fit_to_exact_size(Vec2::splat(16.)));
-                                        });
-                                    ui.vertical(|ui| {
-                                        ui.add_space(2.0);
-                                        ui.add(egui::Separator::default().vertical().grow(7.).spacing(16.));
+                    egui::Frame::new().show(ui, |ui| {
+                        ui.style_mut().spacing.item_spacing = Vec2::ZERO;
+                        egui::Frame::new()
+                            .outer_margin(egui::Margin::same(5))
+                            .inner_margin(egui::Margin::same(5))
+                            .corner_radius(egui::CornerRadius::same(5))
+                            .fill(themes.navbar_widget)
+                            .show(ui, |ui| {
+                                egui::Frame::new().inner_margin(egui::Margin::symmetric(5, 0)).show(ui, |ui| {
+                                    ui.add(Image::new(include_image!("../images/icons/navbar-icon.svg")).fit_to_exact_size(Vec2::splat(16.)));
+                                });
+                                ui.vertical(|ui| {
+                                    ui.add_space(2.0);
+                                    ui.add(egui::Separator::default().vertical().grow(7.).spacing(16.));
+                                });
+                                navbar_menu_buttons(ui);
+                                ui.add_space(8.0);
+                            });
+                        ui.centered_and_justified(|ui| {
+                            egui::Frame::new().show(ui, |ui| {
+                                egui::Frame::new()
+                                    .outer_margin(egui::Margin::symmetric(2, 5))
+                                    .inner_margin(egui::Margin::same(5))
+                                    .corner_radius(egui::CornerRadius::same(5))
+                                    .fill(themes.navbar_widget)
+                                    .show(ui, |ui| {
+                                        ui.add(
+                                            Image::new(include_image!("../images/icons/play-icon.svg"))
+                                                .tint(egui::Color32::GREEN)
+                                                .fit_to_exact_size(Vec2::splat(16.)),
+                                        );
                                     });
-                                    navbar_menu_buttons(ui);
-                                    ui.add_space(8.0);
-                                });
-                            ui.centered_and_justified(|ui| {
-                                egui::Frame::none().show(ui, |ui| {
-                                    egui::Frame::none()
-                                        .outer_margin(egui::Margin::symmetric( 2., 5.))
-                                        .inner_margin(egui::Margin::same(5.))
-                                        .rounding(egui::Rounding::same(5.))
-                                        .fill(themes.navbar_widget)
-                                        .show(ui, |ui| {
-                                            ui.add(Image::new(include_image!("../images/icons/play-icon.svg")).tint(egui::Color32::GREEN).fit_to_exact_size(Vec2::splat(16.)));
-                                        });
-                                });
                             });
                         });
+                    });
                 })
             })
         })

--- a/crates/volt/src/visual/notification.rs
+++ b/crates/volt/src/visual/notification.rs
@@ -1,32 +1,26 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use egui::Color32;
-
-use crate::timings::now_ns;
+use egui::{Color32, hex_color};
 
 #[derive(Debug, Clone)]
 pub struct Notification {
     pub message: String,
     pub duration: Option<Duration>,
-    pub add_time: Duration
+    pub added: Instant,
 }
 
 impl Notification {
     pub fn new(message: String, duration: Option<Duration>) -> Self {
-        let add_time = Duration::from_nanos(now_ns() as u64);
-        Notification {
-            message,
-            duration,
-            add_time
-        }
+        let add_time = Instant::now();
+        Self { message, duration, added: add_time }
     }
 
     pub fn with_duration(message: String, duration: Duration) -> Self {
-        Notification::new(message, Some(duration))
+        Self::new(message, Some(duration))
     }
 
     pub fn without_duration(message: String) -> Self {
-        Notification::new(message, None)
+        Self::new(message, None)
     }
 }
 
@@ -34,11 +28,15 @@ pub struct NotificationDrawer {
     notifications: Vec<Notification>,
 }
 
+impl Default for NotificationDrawer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NotificationDrawer {
-    pub fn new() -> Self {
-        NotificationDrawer {
-            notifications: Vec::new(),
-        }
+    pub const fn new() -> Self {
+        Self { notifications: Vec::new() }
     }
 
     pub fn add_notification(&mut self, notification: Notification) {
@@ -51,7 +49,7 @@ impl NotificationDrawer {
         }
     }
 
-    pub fn get_notifications(&self) -> &Vec<Notification> {
+    pub const fn get_notifications(&self) -> &Vec<Notification> {
         &self.notifications
     }
 
@@ -63,20 +61,19 @@ impl NotificationDrawer {
 
 impl egui::Widget for &mut NotificationDrawer {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
-        let mut response = ui.allocate_response(egui::Vec2::ZERO, egui::Sense::hover());
-
         if !self.notifications.is_empty() {
-            let now = now_ns() as u64;
+            let now = Instant::now();
             let mut indices_to_remove = Vec::new();
 
             for (i, notification) in self.notifications.iter().enumerate() {
-                let age = now - notification.add_time.as_nanos() as u64;
-                let fade_duration_ns = 0.2 * 1_000_000_000.0;
-                let lifetime_ns = notification.duration.map(|d| d.as_nanos() as f64).unwrap_or(f64::MAX);
-                let mut opacity: f32 = if age as f64 <= fade_duration_ns {
-                    (age as f64 / fade_duration_ns) as f32
-                } else if lifetime_ns - age as f64 <= fade_duration_ns {
-                    ((lifetime_ns - age as f64) / fade_duration_ns) as f32
+                let age = notification.added.elapsed();
+                let fade_duration = Duration::from_secs_f32(0.2);
+                let mut opacity = if age <= fade_duration {
+                    age.as_secs_f32() / fade_duration.as_secs_f32()
+                } else if let Some(lifetime) = notification.duration
+                    && lifetime - age <= fade_duration
+                {
+                    (lifetime - age).as_secs_f32() / fade_duration.as_secs_f32()
                 } else {
                     1.0
                 };
@@ -85,16 +82,10 @@ impl egui::Widget for &mut NotificationDrawer {
                     opacity = 0.01;
                 }
 
-                let color = Color32::from_hex("#222222").unwrap().gamma_multiply(opacity);
+                let color = hex_color!("#222222").gamma_multiply(opacity);
 
-                egui::Frame::none().fill(color).inner_margin(egui::Margin::same(10.)).show(ui, |ui| {
-                    let width = ui.ctx().screen_rect().width();
-                    let min_width = if width < 200. {
-                        width
-                    } else {
-                        200.
-                    };
-                    ui.set_min_width(min_width);
+                egui::Frame::new().fill(color).inner_margin(egui::Margin::same(10)).show(ui, |ui| {
+                    ui.set_min_width(ui.ctx().screen_rect().width().min(200.));
                     ui.allocate_ui(ui.available_size(), |ui| {
                         let text_color = Color32::WHITE.gamma_multiply(opacity);
                         ui.label(egui::RichText::new(&notification.message).color(text_color));
@@ -102,10 +93,10 @@ impl egui::Widget for &mut NotificationDrawer {
                 });
 
                 // Schedule removal if a duration is specified
-                if let Some(duration) = notification.duration {
-                    if (notification.add_time.as_nanos() as u64) + (duration.as_nanos() as u64) < now {
-                        indices_to_remove.push(i);
-                    }
+                if let Some(duration) = notification.duration
+                    && notification.added + duration < now
+                {
+                    indices_to_remove.push(i);
                 }
 
                 ui.ctx().request_repaint_after_secs(0.03);
@@ -116,9 +107,9 @@ impl egui::Widget for &mut NotificationDrawer {
                 self.remove_notification(index);
             }
 
-            response = ui.allocate_response(ui.available_size(), egui::Sense::hover());
+            ui.allocate_response(ui.available_size(), egui::Sense::hover());
         }
 
-        response
+        ui.allocate_response(egui::Vec2::ZERO, egui::Sense::hover())
     }
 }

--- a/crates/volt/src/visual/status.rs
+++ b/crates/volt/src/visual/status.rs
@@ -1,5 +1,5 @@
 use eframe::egui;
-use egui::{include_image, Color32, FontFamily, Image, Label, Margin, RichText, TextureOptions, Ui, Vec2, Widget};
+use egui::{FontFamily, Label, Margin, RichText, TextureOptions, Ui, Vec2, Widget, hex_color};
 
 use super::ThemeColors;
 
@@ -21,10 +21,10 @@ pub fn status(themes: &ThemeColors) -> impl Widget + use<'_> {
         ui.horizontal(|ui| {
             egui::Frame::default().show(ui, |ui| {
                 ui.horizontal(|ui| {
-                    egui::Frame::none().show(ui, |ui| {
+                    egui::Frame::new().show(ui, |ui| {
                         ui.style_mut().spacing.item_spacing = Vec2::ZERO;
-                        egui::Frame::none().inner_margin(Margin::same(5.)).show(ui, |ui| {
-                            ui.add(Label::new(RichText::new("Volt v1.0.0").family(FontFamily::Proportional).color(Color32::from_hex("#777490").unwrap())).selectable(false));
+                        egui::Frame::new().inner_margin(Margin::same(5)).show(ui, |ui| {
+                            ui.add(Label::new(RichText::new("Volt v1.0.0").family(FontFamily::Proportional).color(hex_color!("#777490"))).selectable(false));
                         });
                     });
                 })

--- a/crates/volt/src/visual/switch.rs
+++ b/crates/volt/src/visual/switch.rs
@@ -13,7 +13,7 @@ pub fn switch_widget_ui(ui: &mut egui::Ui, on: &mut bool) -> egui::Response {
         let visuals = ui.style().interact_selectable(&response, *on);
         let rect = rect.expand(visuals.expansion);
         let radius = 0.5 * rect.height();
-        ui.painter().rect(rect, radius, visuals.bg_fill, visuals.bg_stroke);
+        ui.painter().rect(rect, radius, visuals.bg_fill, visuals.bg_stroke, egui::StrokeKind::Middle);
         let circle_x = egui::lerp((rect.left() + radius)..=(rect.right() - radius), how_on);
         let center = egui::pos2(circle_x, rect.center().y);
         ui.painter().circle(center, 0.75 * radius, visuals.bg_fill, visuals.fg_stroke);


### PR DESCRIPTION
- Update everything; refactor timing stuff to use Instant/Duration, fix clippy warnings, update dependencies to fix crash on macOS 26